### PR TITLE
Fix for multiple events being skipped during an inotify read

### DIFF
--- a/tools.cpp
+++ b/tools.cpp
@@ -66,7 +66,7 @@ using namespace std;
 AsyncClose *asyncClose;
 
 //Sort files in given directory using mtime from oldest (files not already openned for write).
-vector<string> listFilesDir (char * dir) {
+queue<string> listFilesDir (char * dir) {
 	struct privListDir {          //sort by mtime asc. function
 		static bool files_sorter_asc(TfileListElem const& lhs, TfileListElem const& rhs) {
 			if (lhs.mtime != rhs.mtime)
@@ -86,7 +86,7 @@ vector<string> listFilesDir (char * dir) {
 	char filename[1024];
 	vector<TfileListElem> tmpVec;   //vector for sorting
 	TfileListElem elem;             //element of sorting
-	vector<string> outVec;          //sorted filenames list
+	queue<string> outQueue;          //sorted filenames list
 	struct stat fileStats;          //for file stat
 	struct dirent * ent;            //for dir ent
 	DIR *dirP;
@@ -126,9 +126,9 @@ vector<string> listFilesDir (char * dir) {
 	}
 	sort( tmpVec.begin(), tmpVec.begin() + tmpVec.size(), &privListDir::files_sorter_asc);
 	for (unsigned n=0; n<tmpVec.size(); ++n) {
-		outVec.push_back(tmpVec.at(n).filename);
+		outQueue.push(tmpVec.at(n).filename);
 	}
-	return outVec;
+	return outQueue;
 }
 
 vector<string> explode(const string& str, const char& ch) {

--- a/tools.h
+++ b/tools.h
@@ -130,7 +130,7 @@ private:
 	volatile int _sync;
 };
 
-vector<string> listFilesDir(char * dir);
+queue<string> listFilesDir(char * dir);
 vector<string> explode(const string&, const char&);
 int getUpdDifTime(struct timeval *before);
 int getDifTime(struct timeval *before);


### PR DESCRIPTION
Sometime after 10.0.8, the inotify events were not all processed.  Only the first event in the queue during a read() operation would be used, and anything after that first one would be lost.  This causes files to be skipped in the scandir if a lot of files show up there at once.

Patch changes listFilesDir() to return a &lt;queue&gt; (which operates as a FIFO) instead of a &lt;vector&gt;, so that the queue can continue to be used as  a stack to put work on, and for the reading system to use to find work.

Code that uses inotify system to watch the "scanpcapdir" adds all of the events it reads to the end of the queue, and we simply pop work off the end as needed.

Now, the queue is initialized with anything pre-existing in the directory, code then drops into the "run forever" loop, and processes anything in the queue before checking if inotify buffer has anything to do.

Every time the queue empties out, we go into the blocking read() call, grab any events waiting there, and stick them onto the queue.  The process then repeats, and no files are inadvertently skipped.

Scenario: Imagine 3 inotify events are read at one time during the read() call:

Under the old code, the first event is read off the queue, and the file is processed.  The remaining 2 events are ignored, possibly leaving calls in memory, and obviously not creating a complete SIP trace of a call, if more messages for the calls in the first file are contained in the next 2 files.

With this patch, all three files are pushed into the queue.  The first one is popped out of the queue and processed.  When the loop comes around again, the queue is not empty, and will pop the 2nd file off and process it, and likewise for the 3rd file.

Now that all 3 files are processed, the queue is empty, and we land back at the read() call to get more work.