### PR TITLE
Remove uncommented code from tar.cpp

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -36,8 +36,8 @@ objects = $(shell ls -1 *.cpp | sed 's/\.cpp/.o/' | tr "\n" " ") $(shell ls -1 j
 
 #headers = $(shell ls -1 *.h | tr "\n" " ") $(shell ls -1 jitterbuffer/*.h | tr "\n" " ") $(shell ls -1 jitterbuffer/asterisk/*.h | tr "\n" " ")
 
-JSONLIB = $(shell pkg-config --libs json)
-JSONCFLAGS = $(shell pkg-config --cflags json)
+JSONLIB = $(shell pkg-config --libs @LIBJSON_NAME@)
+JSONCFLAGS = $(shell pkg-config --cflags @LIBJSON_NAME@)
 
 MYSQLLIB = $(shell PATH=$$PATH:/usr/local/mysql/bin/ mysql_config --libs)
 MYSQLINC = $(shell PATH=$$PATH:/usr/local/mysql/bin/ mysql_config --include)
@@ -45,12 +45,13 @@ MYSQLINC = $(shell PATH=$$PATH:/usr/local/mysql/bin/ mysql_config --include)
 GLIBCFLAGS =$(shell pkg-config --cflags glib-2.0)
 GLIBLIB =$(shell pkg-config --libs glib-2.0)
 
+LIBLD=@LIBLD@
 LIBLZMA=@LIBLZMA@
 LIBSSH=@LIBSSH@
 LIBGNUTLS=@LIBGNUTLS@
 LIBGNUTLSSTATIC=@LIBGNUTLSSTATIC@ 
-SHARED_LIBS = -ldl -lpthread -lpcap -lz -lvorbis -lvorbisenc -logg -lodbc ${MYSQLLIB} -lrt -lsnappy -lcurl -lssl -lcrypto ${JSONLIB} ${LIBSSH} -lxml2 -lrrd ${LIBGNUTLS} @LIBTCMALLOC@ ${GLIBLIB} ${LIBLZMA}
-STATIC_LIBS = -static @LIBTCMALLOC@ -lodbc -lltdl -ldl -lrt -lz ${LIBSSH} -lcrypt -lm -lcurl -lssl -lcrypto -static-libstdc++ -static-libgcc -lpcap -lpthread ${MYSQLLIB} -lpthread -lz -lc -lvorbis -lvorbisenc -logg -lrt -lsnappy ${JSONLIB} -lrrd -lxml2 ${GLIBLIB} -lz -ldbi -llzma ${LIBGNUTLSSTATIC} 
+SHARED_LIBS = ${LIBLD} -lpthread -lpcap -lz -lvorbis -lvorbisenc -logg -lodbc ${MYSQLLIB} -lrt -lsnappy -lcurl -lssl -lcrypto ${JSONLIB} ${LIBSSH} -lxml2 -lrrd ${LIBGNUTLS} @LIBTCMALLOC@ ${GLIBLIB} ${LIBLZMA}
+STATIC_LIBS = -static @LIBTCMALLOC@ -lodbc -lltdl ${LIBLD} -lrt -lz ${LIBSSH} -lcrypt -lm -lcurl -lssl -lcrypto -static-libstdc++ -static-libgcc -lpcap -lpthread ${MYSQLLIB} -lpthread -lz -lc -lvorbis -lvorbisenc -logg -lrt -lsnappy ${JSONLIB} -lrrd -lxml2 ${GLIBLIB} -lz -ldbi -llzma ${LIBGNUTLSSTATIC} 
 INCLUDES =  -I/usr/local/include ${MYSQLINC} -I jitterbuffer/ ${JSONCFLAGS} ${GLIBCFLAGS}
 LIBS_PATH = -L/usr/local/lib/ 
 CXXFLAGS +=  -Wall -fPIC -g3 -O2 -march=$(GCCARCH) -mtune=${GCCARCH} ${INCLUDES}
@@ -58,12 +59,13 @@ CFLAGS += ${CXXFLAGS}
 LIBS = ${SHARED_LIBS} 
 LIBS2 = @LIBS2@
 
-
+shared: LDFLAGS += -Wl,--allow-multiple-definition
 shared: cleantest $(objects) 
-	${CXX} $(objects) ${CXXFLAGS} -o voipmonitor ${LIBS} ${LIBS_PATH}
+	${CXX} $(objects) ${LDFLAGS} -o voipmonitor ${LIBS} ${LIBS_PATH}
 
+static: LDFLAGS += -Wl,--allow-multiple-definition
 static: cleantest $(objects) 
-	${CXX} $(objects) ${CXXFLAGS} -o voipmonitor ${STATIC_LIBS} ${LIBS_PATH} -Wl,--allow-multiple-definition
+	${CXX} $(objects) ${LDFLAGS} -o voipmonitor ${STATIC_LIBS} ${LIBS_PATH}
 
 core2: cleantest static
 

--- a/configure.in
+++ b/configure.in
@@ -12,8 +12,8 @@ AC_PROG_CC
 AC_PROG_INSTALL
 AC_PROG_MAKE_SET
 
-LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/lib:/usr/local/mysql/lib"
-LDFLAGS="$LDFLAGS -L/usr/local/mysql/lib -L/usr/local/lib -L/usr/lib64/mysql/ -L/usr/lib/mysql/"
+LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/lib:/usr/local/mysql/lib:/usr/local/lib/mysql"
+LDFLAGS="$LDFLAGS -L/usr/local/mysql/lib -L/usr/local/lib -L/usr/lib64/mysql/ -L/usr/lib/mysql/ -L /usr/local/lib/mysql"
 
 # Checks for libraries.
 # FIXME: Replace `main' with a function in `-lc':
@@ -21,7 +21,7 @@ AC_CHECK_LIB([c], [main])
 # FIXME: Replace `main' with a function in `-lcrypt':
 AC_CHECK_LIB([crypt], [main])
 # FIXME: Replace `main' with a function in `-ldl':
-AC_CHECK_LIB([dl], [main])
+AC_CHECK_LIB([dl], [main], AC_SUBST([LIBLD],["-ldl"]), AC_MSG_NOTICE([Unable to find libdl. Safe to ignore on FreeBSD as the functionality is provided by libc.]))
 # FIXME: Replace `main' with a function in `-lltdl':
 AC_CHECK_LIB([ltdl], [main])
 # FIXME: Replace `main' with a function in `-lm':
@@ -46,7 +46,13 @@ AC_CHECK_LIB([vorbisenc], [main], ,AC_MSG_ERROR([Unable to find VORBISENC librar
 AC_CHECK_LIB([snappy], [main], ,AC_MSG_ERROR([Unable to find snappy library. apt-get install libsnappy-dev | or compile from source: https://snappy.googlecode.com/files/snappy-1.1.0.tar.gz]))
 AC_CHECK_LIB([curl], [main], , AC_MSG_ERROR([Unable to find curl library. apt-get libcurl4-openssl-dev | yum curl-devel]))
 AC_CHECK_LIB([ssh], [ssh_forward_accept], HAVE_LIBSSH=1, AC_MSG_NOTICE([Your libssh is old or missing - cloud feature is disabled. apt-get install libssh-dev | yum install libssh-devel | or compile from source https://red.libssh.org/projects/libssh/files]))
-AC_CHECK_LIB([json], [main], , AC_MSG_ERROR([Unable to find json-c library. apt-get install libjson0-dev | yum install json-c-devel (RPM from EPEL) | or compile from source: git clone https://github.com/json-c/json-c.git; cd json-c; sh autogen.sh; ./configure; make; make install;ldconfig]))
+AC_CHECK_LIB([json], [main], LIBJSON_NAME='json', AC_MSG_NOTICE([Unable to find json library - then you must use json-c]))
+AC_CHECK_LIB([json-c], [main], LIBJSON_NAME='json-c', AC_MSG_NOTICE([Unable to find json-c library - this is a problem if json was not found]))
+if test "x$LIBJSON_NAME" = "x"; then
+	AC_MSG_ERROR([Unable to find json(-c) library. apt-get install libjson0-dev | yum install json-c-devel (RPM from EPEL) | pkg install json-c | or compile from source: git clone https://github.com/json-c/json-c.git; cd json-c; sh autogen.sh; ./configure; make; make install;ldconfig])
+else
+	AC_SUBST([LIBJSON_NAME],["$LIBJSON_NAME"])
+fi
 AC_CHECK_LIB([rrd], [main], , AC_MSG_ERROR([Unable to find librrd library. apt-get install librrd-dev | yum install rrdtool-devel | or compile from source http://oss.oetiker.ch/rrdtool/doc/librrd.en.html]))
 AC_CHECK_LIB([glib-2.0], [main], , AC_MSG_ERROR([Unable to find libglib library. apt-get install  libglib2.0-dev | yum install glib2-devel]))
 AC_CHECK_LIB([xml2], [main], , AC_MSG_ERROR([Unable to find xml2 library. apt-get install libxml2-dev | yum install libxml2-devel]))

--- a/tar.cpp
+++ b/tar.cpp
@@ -74,16 +74,6 @@ extern int terminating;
 extern TarQueue *tarQueue;
 extern volatile unsigned int glob_last_packet_time;
 
-#ifdef FREEBSD
-#include "ansidecl.h"
-#include <stddef.h>
-extern PTR memcpy (PTR, const PTR, size_t);
-PTR
-mempcpy (PTR dst, const PTR src, size_t len)
-{
-       return (char *) memcpy (dst, src, len) + len;
-}
-#endif
 
 map<void*, unsigned int> okTarPointers;
 volatile int _sync_okTarPointers;
@@ -166,14 +156,6 @@ Tar::th_set_device(dev_t device)
 void
 Tar::th_set_user(uid_t uid)
 {
-	/*  slow function getpwuid - disabled
-	struct passwd *pw;
-
-	pw = getpwuid(uid);
-	if (pw != NULL)
-		*((char *)mempcpy(tar.th_buf.uname, pw->pw_name, sizeof(tar.th_buf.uname))) = '\0';
-	*/
-
 	int_to_oct(uid, tar.th_buf.uid, 8);
 }
 
@@ -182,15 +164,6 @@ Tar::th_set_user(uid_t uid)
 void
 Tar::th_set_group(gid_t gid)
 {
-
-/*
-	struct group *gr;
-
-	gr = getgrgid(gid);
-	if (gr != NULL)
-		*((char *)mempcpy(tar.th_buf.gname, gr->gr_name, sizeof(tar.th_buf.gname))) = '\0';
-*/
-
 	int_to_oct(gid, tar.th_buf.gid, 8);
 }
 


### PR DESCRIPTION
FreeBSD does not implement mempcpy.

A common workaround is to add mempcpy via the auxilary gcc library ansidecl.h. This is however only available when using gcc.

On FreeBSD we prefer to compile using clang. The interesting thing is that mempcpy is not even used in the code as it has been commented out for a long time. We then require ansidecl.h on FreeBSD even though it is never used.

Because of this I have removed the unused code to get a clean compile with clang. Other workarounds would be possible but seems to be a waste of time.