### PR TITLE
Adjust the init script to allow the reading of a defaults file

### DIFF
--- a/config/init.d/voipmonitor
+++ b/config/init.d/voipmonitor
@@ -18,12 +18,27 @@
 # on debian, run update-rc.d voipmonitor defaults 
 
 ulimit -c unlimited
+
+BASE=$(basename $0)
+
 PATH=/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin
 TERM="linux";
-# uncomment and change interface if you do not have voipmonitor.conf 
+
+# uncomment and change interface if you do not have voipmonitor.conf
 ARGS="-v 1"
 PIDFILE=/var/run/voipmonitorinitscript.pid
 CONFIGFILE=/etc/voipmonitor.conf
+
+RUN="yes"
+
+if [ -f /etc/default/$BASE ]; then
+        . /etc/default/$BASE
+fi
+
+if [ "$RUN" != "yes" ];then
+        echo "Voipmonitor not yet configured. Edit /etc/default/$BASE first."
+        exit 0
+fi
 
 case "$1" in
   start)


### PR DESCRIPTION
Hello,

The following patch allows setting an /etc/defaults/voipmonitor file to overwrite settings without having to edit the init file directly. Out of the box, it works the same for end users as without the patch.

It also exposes a RUN variable that can be set in the /etc/defaults/voipmonitor file to indicate the process can't be started. This is some groundwork to package the sniffer package as a Debian package (dpkg install fails because it can't start the process without a working config).

This is a dependency for PR #16 