### PR TITLE
Changed filter_telnum.prefix to char(20) during mysql create table

### DIFF
--- a/sql_db.cpp
+++ b/sql_db.cpp
@@ -2954,7 +2954,7 @@ bool SqlDb_mysql::createSchema(SqlDb *sourceDb) {
 	this->query(
 	"CREATE TABLE IF NOT EXISTS `filter_telnum` (\
 			`id` int NOT NULL AUTO_INCREMENT,\
-			`prefix` bigint unsigned DEFAULT NULL,\
+			`prefix` char(20) DEFAULT NULL,\
 			`fixed_len` int unsigned DEFAULT '0',\
 			`direction` tinyint DEFAULT NULL,\
 			`rtp` tinyint DEFAULT NULL,\


### PR DESCRIPTION
I think the mysql bigint type is not appropriate for representing telephone numbers.
I noticed that the "voipmonitor commercial php GUI", while performing his initial setup, alters this field to char(20), as a consequence I changed the sql_db.cpp file.