### PR TITLE
Deleted "strip white spaces"  iteration

### DIFF
--- a/sniff.cpp
+++ b/sniff.cpp
@@ -2909,7 +2909,6 @@ Call *process_packet(packet_s *packetS, void *_parsePacketPreproc,
 								break;
 							}
 						}
-						while(type[pointerToCause - reason - i] == ' ') type[pointerToCause - reason - i] = 0;
 						int cause = atoi(pointerToCause + 7);
 						char text[1024];
 						char *pointerToText = strcasestr(pointerToCause, ";text=\"");


### PR DESCRIPTION
With commit 2f43ebfdf48ec395bdbed36696203820344ba696 , at row 2912 this row was introduced:
+						while(type[pointerToCause - reason - i] == ' ') type[pointerToCause - reason - i] = 0;
I think it's wrong.

That row prevents my voipmonitor installation to be compiled, in addition it's weird, the variable i is not in this scope, it never gets decremented and it seems it would make the some work of the immediatly above for iteration, please let me know if I am wrong @voipmonitor 