### PR TITLE
keep stun and dtls packets intact in rtpheader mode

### DIFF
--- a/calltable.cpp
+++ b/calltable.cpp
@@ -1958,7 +1958,8 @@ Call::_save_rtp(packet_s *packetS, char is_fax, char enable_save_packet, bool re
 		}
 	}
 	if(enable_save_packet) {
-		if((this->silencerecording || (this->flags & FLAG_SAVERTPHEADER)) && !this->isfax && !record_dtmf) {
+		if ((this->silencerecording || (this->flags & FLAG_SAVERTPHEADER)) &&
+		    !this->isfax && !record_dtmf && !packetS->isStun() && !packetS->isDtls()) {
 			if(packetS->datalen_() >= RTP_FIXED_HEADERLEN &&
 			   packetS->header_pt->caplen > (unsigned)(packetS->datalen_() - RTP_FIXED_HEADERLEN)) {
 				unsigned int tmp_u32 = packetS->header_pt->caplen;
@@ -1967,7 +1968,8 @@ Call::_save_rtp(packet_s *packetS, char is_fax, char enable_save_packet, bool re
 				save_packet(this, packetS, TYPE_RTP);
 				packetS->header_pt->caplen = tmp_u32;
 			}
-		} else if((this->flags & FLAG_SAVERTP) || this->isfax || record_dtmf) {
+		} else if((this->flags & FLAG_SAVERTP) || this->isfax ||
+		          record_dtmf || packetS->isStun() || packetS->isDtls()) {
 			save_packet(this, packetS, TYPE_RTP, forceVirtualUdp);
 		}
 	}

--- a/calltable.cpp
+++ b/calltable.cpp
@@ -1958,18 +1958,18 @@ Call::_save_rtp(packet_s *packetS, char is_fax, char enable_save_packet, bool re
 		}
 	}
 	if(enable_save_packet) {
-		if ((this->silencerecording || (this->flags & FLAG_SAVERTPHEADER)) &&
-		    !this->isfax && !record_dtmf && !packetS->isStun() && !packetS->isDtls()) {
-			if(packetS->datalen_() >= RTP_FIXED_HEADERLEN &&
-			   packetS->header_pt->caplen > (unsigned)(packetS->datalen_() - RTP_FIXED_HEADERLEN)) {
+		if((this->silencerecording || (this->flags & FLAG_SAVERTPHEADER)) && !this->isfax && !record_dtmf) {
+			if(packetS->isStun() || packetS->isDtls()) {
+				save_packet(this, packetS, TYPE_RTP, forceVirtualUdp);
+			} else if(packetS->datalen_() >= RTP_FIXED_HEADERLEN &&
+			          packetS->header_pt->caplen > (unsigned)(packetS->datalen_() - RTP_FIXED_HEADERLEN)) {
 				unsigned int tmp_u32 = packetS->header_pt->caplen;
 				packetS->header_pt->caplen = min(packetS->header_pt->caplen - (packetS->datalen_() - RTP_FIXED_HEADERLEN),
 								 packetS->dataoffset_() + RTP_FIXED_HEADERLEN);
 				save_packet(this, packetS, TYPE_RTP);
 				packetS->header_pt->caplen = tmp_u32;
 			}
-		} else if((this->flags & FLAG_SAVERTP) || this->isfax ||
-		          record_dtmf || packetS->isStun() || packetS->isDtls()) {
+		} else if((this->flags & FLAG_SAVERTP) || this->isfax || record_dtmf) {
 			save_packet(this, packetS, TYPE_RTP, forceVirtualUdp);
 		}
 	}

--- a/sniff.h
+++ b/sniff.h
@@ -56,6 +56,8 @@ struct sll_header {
 };
 
 #define IS_RTP(data, datalen) ((datalen) >= 2 && (htons(*(u_int16_t*)(data)) & 0xC000) == 0x8000)
+#define IS_STUN(data, datalen) ((datalen) >= 2 && (htons(*(u_int16_t*)(data)) & 0xC000) == 0x0)
+#define IS_DTLS(data, datalen) ((datalen) >= 2 && (htons(*(u_int16_t*)(data)) & 0xFF00) < 0x4000)
 
 enum e_packet_s_type {
 	_t_packet_s = 1,
@@ -219,6 +221,12 @@ struct packet_s {
 	}
 	inline bool isRtp() {
 		return(IS_RTP(data_(), datalen_()));
+	}
+	inline bool isStun() {
+		return(IS_STUN(data_(), datalen_()));
+	}
+	inline bool isDtls() {
+		return(IS_DTLS(data_(), datalen_()));
 	}
 	inline bool isUdptl() {
 		return(!IS_RTP(data_(), datalen_()));


### PR DESCRIPTION
When `savertp = header` is used, stun and dtls packets are also truncated and they become of no use. So I have added checks to exclude these packets based on https://tools.ietf.org/html/rfc5764#section-5.1.2