### PR TITLE
CURL WAV convert end hook

### DIFF
--- a/config/voipmonitor.conf
+++ b/config/voipmonitor.conf
@@ -1562,5 +1562,3 @@ dscp = yes
 
 # Base URL for curl hook
 #curl_hook_wav = http://127.0.0.1:8080/you-script-path
-# Pass sensor_id as a server_id parameter in hook JSON data
-#curl_hook_sensor_id_as_server_id = no

--- a/config/voipmonitor.conf
+++ b/config/voipmonitor.conf
@@ -1559,3 +1559,8 @@ dscp = yes
 
 #ss7 = yes
 #ss7_rudp_port = 7000
+
+# Base URL for curl hook
+#curl_hook_wav = http://127.0.0.1:8080/you-script-path
+# Pass sensor_id as a server_id parameter in hook JSON data
+#curl_hook_sensor_id_as_server_id = no

--- a/tools.h
+++ b/tools.h
@@ -364,6 +364,8 @@ struct s_get_url_response_params {
 };
 bool get_url_response(const char *url, SimpleBuffer *response, vector<dstring> *postData, string *error = NULL,
 		      s_get_url_response_params *params = NULL);
+bool post_url_response(const char *url, SimpleBuffer *response, string *postData, string *error = NULL,
+		      s_get_url_response_params *params = NULL);
 long long GetFileSize(std::string filename);
 time_t GetFileCreateTime(std::string filename);
 long long GetFileSizeDU(std::string filename, eTypeSpoolFile typeSpoolFile, int spool_index, int dirItemSize = -1);

--- a/voipmonitor.cpp
+++ b/voipmonitor.cpp
@@ -1172,6 +1172,10 @@ int opt_process_pcap_type = 0;
 char opt_pcap_destination[1024];
 cConfigItem_net_map::t_net_map opt_anonymize_ip_map;
 
+// SANCOM options BEGIN
+char opt_curl_hook_wav[256] = "";
+// SANCOM options END
+
 
 #include <stdio.h>
 #include <pthread.h>
@@ -6926,6 +6930,7 @@ void cConfig::addConfigItems() {
 					expert();
 					addConfigItem(new FILE_LINE(0) cConfigItem_yesno("saveaudio_dedup_seq", &opt_saveaudio_dedup_seq));
 					addConfigItem(new FILE_LINE(42230) cConfigItem_yesno("plcdisable", &opt_disableplc));
+					addConfigItem(new FILE_LINE(1162) cConfigItem_string("opt_curl_hook_wav", opt_curl_hook_wav, sizeof(opt_curl_hook_wav)));
 		setDisableIfEnd();
 	group("data spool directory cleaning");
 		setDisableIfBegin("sniffer_mode=" + snifferMode_sender_str);
@@ -11784,6 +11789,10 @@ int eval_config(string inistr) {
 	}
 	if((value = ini.GetValue("general", "abort_if_rss_gt_gb", NULL))) {
 		opt_abort_if_rss_gt_gb = atoi(value);
+	}
+	
+	if((value = ini.GetValue("general", "opt_curl_hook_wav", NULL))) {
+		strcpy_null_term(opt_curl_hook_wav, value);
 	}
 	
 	/*


### PR DESCRIPTION
This patch allow to set up a WEB hook, which will be called every time WAV file is ready after convertation is done.
Config parameters example:
```
# Base URL for curl hook
curl_hook_wav = http://127.0.0.1:8080/you-script-path
# Pass sensor_id as a server_id parameter in hook JSON data
curl_hook_sensor_id_as_server_id = no

```
