### PR TITLE
Kamailo mirroring related fix

### DIFF
--- a/sniff.cpp
+++ b/sniff.cpp
@@ -10019,7 +10019,7 @@ void PreProcessPacket::process_sip(packet_s_process **packetS_ref) {
 					unsigned long l = i == 0 ? from_ip_l : to_ip_l;
 					char *p_sep_ip = strnchr(ip, ':', l);
 					if(p_sep_ip) {
-						char *p_sep_port = strnchr(p_sep_ip + 1, ':', l - (p_sep_ip - ip));
+						char *p_sep_port = strnrchr(p_sep_ip + 1, ':', l - (p_sep_ip - ip));
 						if(p_sep_port) {
 							is_tcp[i] = ip[0] == 't' || ip[0] == 'T';
 							string str_ip = string(p_sep_ip + 1, p_sep_port - p_sep_ip - 1);

--- a/tools.h
+++ b/tools.h
@@ -473,6 +473,7 @@ unsigned long getUptime();
 char *strnstr(const char *haystack, const char *needle, size_t len);
 char *strncasestr(const char *haystack, const char *needle, size_t len);
 char *strnchr(const char *haystack, char needle, size_t len);
+char *strnrchr(const char *haystack, char needle, size_t len);
 char *strncasechr(const char *haystack, char needle, size_t len);
 int strcasecmp_wildcard(const char *str, const char *pattern, const char *wildcard);
 int strncasecmp_wildcard(const char *str, const char *pattern, size_t len, const char *wildcard);


### PR DESCRIPTION
Hi !

This patch are related to kamailio mirroring. 

What this patch do - suppose we work in mixed IPv6/IPv4 enviroment, we configure kamailio siptrace diplication to IPv6
address and configure voipmonitor to listen at kamailio_dstip=[IPv6_address],
when signaling duplicated from IPv6 segment we have the first problem - wrong parsing of kamailio extra headers 
which contains IPv6 in URI.
The second problem appears when duplication packet from different address family, 
for example, kamailio_dstip=[IPv6_address] (voipmonitor capturing V6 packet) and URI in kamailio extra headers are IPv4 addresses, 
in this case current implementation make wrong encapsulation of pcap packet - eth headr contains IPv6 protocol type, but real payload is IPv4, can be in reverse also, if voipmonitor listen at IPv4, but frame mirrored from IPv6.
