### PR TITLE
VS-1683: Add support for a pcap filter per defined interface

### DIFF
--- a/config/voipmonitor.conf
+++ b/config/voipmonitor.conf
@@ -330,11 +330,19 @@ interface = eth0
 # Rare use cases may require a larger snapshot length.
 #snaplen = 20000
 
+# Apply a different packet capture filter to each interface.
+# For example when 'interface = eth0,eth1' and filter_multi_interface is enabled.
+# you can do 'filter = port 5060;port 5090' to filter on port 5060 or 5090 on eth0 and eth1 respectively.
+# When enabled, the number of ; separated values in `filter` must match the number of interfaces in `interface`.
+# default is no
+#filter_multi_interface = no
+
 # Packet Capture Filter
 # Specify a PCAP filter to limit the types of packets that are captured.
 # Example: 'udp' will capture only UDP packets, but won't capture VLAN packets.
 # WARNING - if you need to sniff IPinIP (mirrored packets from voipmonitor) filter = udp will filter all those packets. In this case just disable filter.
 # WARNING - this rule "udp or (vlan and udp)" will not capture double VLAN tagged packets
+# Separate filters with ; character if filter_multi_interface is enabled
 #filter = udp or (vlan and udp)
 
 # IP Filter for Sniffing

--- a/pcap_queue.cpp
+++ b/pcap_queue.cpp
@@ -108,6 +108,7 @@ extern char *httpportmatrix;
 extern char *webrtcportmatrix;
 extern char *diameter_tcp_portmatrix;
 extern MirrorIP *mirrorip;
+extern int opt_multi_filter;
 extern char user_filter[10*2048];
 extern Calltable *calltable;
 extern volatile int calls_counter;
@@ -3905,6 +3906,10 @@ void PcapQueue_readFromInterface_base::setInterfaceName(const char *interfaceNam
 	this->interfaceName = interfaceName;
 }
 
+void PcapQueue_readFromInterface_base::setFilter(const char *filter) {
+	this->filter = filter;
+}
+
 bool PcapQueue_readFromInterface_base::startCapture(string *error, sDpdkConfig *dpdkConfig) {
 	*error = "";
 	static volatile int _sync_start_capture = 0;
@@ -3948,7 +3953,7 @@ bool PcapQueue_readFromInterface_base::startCapture(string *error, sDpdkConfig *
 		return(true);
 	}
 	if(VERBOSE) {
-		syslog(LOG_NOTICE, "packetbuffer - %s: capturing", this->getInterfaceName().c_str());
+		syslog(LOG_NOTICE, "packetbuffer - %s: capturing - pcap filter: %s", this->getInterfaceName().c_str(), this->filter.length() > 0 ? this->filter.c_str() : "<none>");
 	}
 	if(opt_use_dpdk && dpdkConfig && dpdkConfig->device[0]) {
 		this->dpdkHandle = create_dpdk_handle();
@@ -4033,12 +4038,12 @@ bool PcapQueue_readFromInterface_base::startCapture(string *error, sDpdkConfig *
 			mirrorip = new FILE_LINE(15024) MirrorIP(opt_mirrorip_src, opt_mirrorip_dst);
 		}
 	}
-	if(*user_filter != '\0') {
+	if(*this->filter.c_str() != '\0') {
 		// Compile and apply the filter
 		struct bpf_program fp;
-		if (pcap_compile(this->pcapHandle, &fp, user_filter, 0, this->interfaceMask) == -1) {
+		if (pcap_compile(this->pcapHandle, &fp, this->filter.c_str(), 0, this->interfaceMask) == -1) {
 			char user_filter_err[2048];
-			snprintf(user_filter_err, sizeof(user_filter_err), "%.2000s%s", user_filter, strlen(user_filter) > 2000 ? "..." : "");
+			snprintf(user_filter_err, sizeof(user_filter_err), "%.2000s%s", this->filter.c_str(), strlen(this->filter.c_str()) > 2000 ? "..." : "");
 			snprintf(errorstr, sizeof(errorstr), "packetbuffer - %s: can not parse filter %s: %s", this->getInterfaceName().c_str(), user_filter_err, pcap_geterr(this->pcapHandle));
 			if(opt_fork) {
 				ostringstream outStr;
@@ -4049,7 +4054,7 @@ bool PcapQueue_readFromInterface_base::startCapture(string *error, sDpdkConfig *
 		}
 		if (pcap_setfilter(this->pcapHandle, &fp) == -1) {
 			char user_filter_err[2048];
-			snprintf(user_filter_err, sizeof(user_filter_err), "%.2000s%s", user_filter, strlen(user_filter) > 2000 ? "..." : "");
+			snprintf(user_filter_err, sizeof(user_filter_err), "%.2000s%s", this->filter.c_str(), strlen(this->filter.c_str()) > 2000 ? "..." : "");
 			snprintf(errorstr, sizeof(errorstr), "packetbuffer - %s: can not install filter %s: %s", this->getInterfaceName().c_str(), user_filter_err, pcap_geterr(this->pcapHandle));
 			if(opt_fork) {
 				ostringstream outStr;
@@ -4801,6 +4806,7 @@ PcapQueue_readFromInterfaceThread::PcapQueue_readFromInterfaceThread(const char 
 	this->headerPacketStackSnaplen = NULL;
 	this->headerPacketStackShort = NULL;
 	this->headerPacketStackShortPacketLen = 0;
+	this->filter = filter;
 	if(typeThread == read) {
 		this->headerPacketStackSnaplen = new FILE_LINE(15030) cHeaderPacketStack(opt_pcap_queue_iface_qring_size, get_pcap_snaplen());
 		if(opt_pcap_queue_iface_dedup_separate_threads_extend == 2) {
@@ -6673,6 +6679,10 @@ void PcapQueue_readFromInterface::setInterfaceName(const char* interfaceName) {
 	this->interfaceName = interfaceName;
 }
 
+void PcapQueue_readFromInterface::setFilter(const char* filter) {
+	this->filter = filter;
+}
+
 void PcapQueue_readFromInterface::terminate() {
 	for(int i = 0; i < this->readThreadsCount; i++) {
 		this->readThreads[i]->terminate();
@@ -6681,14 +6691,22 @@ void PcapQueue_readFromInterface::terminate() {
 }
 
 bool PcapQueue_readFromInterface::init() {
+	vector<string> filters;
+
 	if(opt_scanpcapdir[0] ||
 	   !opt_pcap_queue_iface_separate_threads) {
 		return(true);
 	}
 	vector<string> interfaces = split(this->interfaceName.c_str(), split(",|;| |\t|\r|\n", "|"), true);
+
+	if (opt_multi_filter) {
+		filters = split(this->filter.c_str(), ';');
+	}
+
 	for(size_t i = 0; i < interfaces.size(); i++) {
 		if(this->readThreadsCount < READ_THREADS_MAX - 1) {
 			this->readThreads[this->readThreadsCount] = new FILE_LINE(15047) PcapQueue_readFromInterfaceThread(interfaces[i].c_str(), PcapQueue_readFromInterfaceThread::read, NULL, NULL, this);
+			this->readThreads[this->readThreadsCount]->setFilter(opt_multi_filter ? filters[i].c_str() : this->filter.c_str());
 			++this->readThreadsCount;
 		}
 	}

--- a/pcap_queue.h
+++ b/pcap_queue.h
@@ -423,6 +423,7 @@ public:
 	PcapQueue_readFromInterface_base(const char *interfaceName = NULL);
 	virtual ~PcapQueue_readFromInterface_base();
 	void setInterfaceName(const char *interfaceName);
+	void setFilter(const char *filter);
 protected:
 	virtual bool startCapture(string *error, sDpdkConfig *dpdkConfig);
 	inline int pcap_next_ex_iface(pcap_t *pcapHandle, pcap_pkthdr** header, u_char** packet,
@@ -450,6 +451,7 @@ protected:
 	virtual inline void tryForcePush() {}
 protected:
 	string interfaceName;
+	string filter;
 	bpf_u_int32 interfaceNet;
 	bpf_u_int32 interfaceMask;
 	pcap_t *pcapHandle;
@@ -890,6 +892,7 @@ public:
 	PcapQueue_readFromInterface(const char *nameQueue);
 	virtual ~PcapQueue_readFromInterface();
 	void setInterfaceName(const char *interfaceName);
+	void setFilter(const char *filter);
 	void terminate();
 	bool openPcap(const char *filename, string *tempFileName = NULL);
 	bool isPcapEnd() {

--- a/voipmonitor.cpp
+++ b/voipmonitor.cpp
@@ -1095,6 +1095,7 @@ bool opt_scanpcapdir_disable_inotify = false;
 int opt_scanpcapmethod = IN_CLOSE_WRITE; // Specifies how to watch for new files in opt_scanpcapdir
 #endif
 int opt_promisc = 1;	// put interface to promisc mode?
+int opt_multi_filter = 0;
 int opt_use_oneshot_buffer = 1;
 int opt_snaplen = 0;
 char pcapcommand[4092] = "";
@@ -3745,7 +3746,29 @@ int main(int argc, char *argv[]) {
 			return(0);
 		}
 	}
-	
+
+	if (opt_multi_filter) {
+		if (opt_pcap_queue_disable) {
+			puts("Filter per interface is not supported when packetbuffer is disabled.\n");
+			return(0);
+		}
+
+		// @todo Create a separate filter config for pcap dir scanning
+		if (opt_scanpcapdir[0] != '\0') {
+			puts("Filter per interface is not supported when scanpcapdir is enabled.\n");
+			return(0);
+		}
+
+		// `filter` must have the same number of items as `interface`
+		std::string filters = user_filter;
+		std::string interfaces = ifname;
+
+		if (std::count(filters.begin(), filters.end(), ';') != std::count(interfaces.begin(), interfaces.end(), ',')) {
+			puts("Number of filters must match number of interfaces.\n");
+			return(0);
+		}
+	}
+
 	if(updateSchema) {
 		SipHistorySetting();
 		return(SqlInitSchema() > 0 ? 0 : 1);
@@ -5115,6 +5138,7 @@ int main_init_read() {
 						     is_read_from_file_by_pb() ? 
 						      "read_from_file" :
 						      "scanpcapdir");
+			pcapQueueI->setFilter(user_filter);
 			pcapQueueI->setEnableAutoTerminate(false);
 		}
 		
@@ -6348,6 +6372,7 @@ void cConfig::addConfigItems() {
 					addConfigItem(new FILE_LINE(0) cConfigItem_string("dpdk_vdev", &opt_dpdk_vdev));
 			normal();
 			addConfigItem(new FILE_LINE(42135) cConfigItem_yesno("promisc", &opt_promisc));
+			addConfigItem(new FILE_LINE(42135) cConfigItem_yesno("filter_multi_interface", &opt_multi_filter));
 			addConfigItem(new FILE_LINE(42136) cConfigItem_string("filter", user_filter, sizeof(user_filter)));
 			addConfigItem(new FILE_LINE(42137) cConfigItem_ip_port("mirror_bind", &opt_pcap_queue_receive_from_ip_port));
 			addConfigItem((new FILE_LINE(42138) cConfigItem_string("mirror_bind_ip"))


### PR DESCRIPTION
Adds new filter_multi_interface config parameter which, when enabled, treats filter config as a ; separated list of filters

First filter applies to first interface, second to second interface, and so on

Not supported when packetbuffer is disabled or when reading pcaps from a spool dir