### PR TITLE
set rtp flag from response

### DIFF
--- a/sniff.cpp
+++ b/sniff.cpp
@@ -4759,9 +4759,10 @@ void process_packet_sip_call(packet_s_process *packetS) {
 	if(!packetS->_createCall) {
 		unsigned long int flags = call->flags;
 		if(SIP_HEADERfilter::add_call_flags(&packetS->parseContents, &flags, NULL)) {
-			if((call->flags & FLAG_SAVERTP) && !(flags & FLAG_SAVERTP)) {
-				call->flags &= ~FLAG_SAVERTP;
-			}
+			/* Apply both FLAG_SAVERTP and FLAG_SAVERTPHEADER from filter - when filter sets full RTP
+			   it clears FLAG_SAVERTPHEADER, which we must copy or we'd still truncate to header-only */
+			unsigned long rtp_mask = FLAG_SAVERTP | FLAG_SAVERTPHEADER;
+			call->flags = (call->flags & ~rtp_mask) | (flags & rtp_mask);
 			if((call->flags & FLAG_SAVEAUDIO) && !(flags & FLAG_SAVEAUDIO)) {
 				call->flags &= ~FLAG_SAVEAUDIO;
 			}


### PR DESCRIPTION
In my use case, the global config has `savertp = header`, but I need to store RTP payload for some of the traffic. I am doing this using `capture_rules_sip_header_file = /opt/voipmonitor/capturerules_sip_header.csv` (see below for its content). I couldn't control the headers in the inbound calls, and I could only control the response to the INVITE. The 200 OK (INVITE) contains the header `X-STORE-RTP`. However, `call-flags` is not updated in this case. This PR addresses this. Please help to take a look!

```
header,content,content_type,rtp
X-STORE-RTP,^ *1 *$,regexp,1
```