### PR TITLE
Saving BFCP to pcap.

### DIFF
--- a/calltable.cpp
+++ b/calltable.cpp
@@ -2028,6 +2028,9 @@ bool Call::read_rtp(CallBranch *c_branch, packet_s_process_0 *packetS, int iscal
 			save_packet(this, packetS, _t_packet_mrcp, 0, 0, __FILE__, __LINE__);
 		}
 		return(true);
+	}else if(packetS->pflags.is_bfcp()) {
+		save_packet(this, packetS, _t_packet_bfcp, 0, 0, __FILE__, __LINE__);
+		return(true);
 	}
 	extern bool opt_null_rtppayload;
 	if(opt_null_rtppayload) {

--- a/calltable.h
+++ b/calltable.h
@@ -303,7 +303,8 @@ enum e_sdp_protocol {
 	sdp_proto_t38,
 	sdp_proto_msrp,
 	sdp_proto_sprt,
-	sdp_proto_tcp_mrcpv2
+	sdp_proto_tcp_mrcpv2,
+	sdp_proto_bfcp
 };
 
 struct s_sdp_flags : public s_sdp_flags_base {

--- a/filter_mysql.h
+++ b/filter_mysql.h
@@ -428,6 +428,10 @@ public:
 		return(opt_saveMRCP ||
 		       (getGlobalFlags() & _gf_mrcp));
 	}
+	static inline bool saveBfcp() {
+		extern int opt_saveBFCP;
+		return opt_saveBFCP;
+	}
 public:
 	static u_int32_t global_flags;
 	static u_int32_t reload_global_flags;

--- a/pcap_queue.cpp
+++ b/pcap_queue.cpp
@@ -10138,6 +10138,9 @@ bool PcapQueue_readFromFifo::processPacket_analysis(sHeaderPacketPQout* hp) {
 			sport = header_udp->get_source();
 			dport = header_udp->get_dest();
 			pflags.set_ss7(opt_enable_ss7 && (ss7_rudp_portmatrix[sport] || ss7_rudp_portmatrix[dport]));
+			if (IS_BFCP(data, datalen)){
+				pflags.set_bfcp(true);
+			}
 		} else if(header_ip_protocol == IPPROTO_TCP) {
 			tcphdr2 *header_tcp = (tcphdr2*)((char*)header_ip + header_ip->get_hdr_size());
 			datalen = get_tcp_data_len(header_ip, header_tcp, &data, hp->packet, header->caplen);
@@ -10148,6 +10151,8 @@ bool PcapQueue_readFromFifo::processPacket_analysis(sHeaderPacketPQout* hp) {
 				pflags.set_ss7(true);
 			} else if(cFilters::saveMrcp() && IS_MRCP(data, datalen)) {
 				pflags.set_mrcp(true);
+			} else if(IS_BFCP(data, datalen)){
+				pflags.set_bfcp(true);
 			}
 		} else if(opt_enable_ss7 && header_ip_protocol == IPPROTO_SCTP) {
 			pflags.set_ss7(true);

--- a/pcap_queue_block.h
+++ b/pcap_queue_block.h
@@ -605,7 +605,8 @@ struct packet_flags {
 	static const uint16_t DTLS_HANDSHAKE_MASK = (1 << 7);
 	static const uint16_t DIAMETER_MASK       = (1 << 8);
 	static const uint16_t IPFIX_QOS_MASK       = (1 << 8);
-	
+	static const uint16_t BFCP_MASK           = (1 << 9);
+
 	uint16_t flags;
 
 	inline void init() { flags = 0; }
@@ -618,6 +619,10 @@ struct packet_flags {
 	
 	inline void set_mrcp(bool value) { flags = (flags & ~MRCP_MASK) | (value ? MRCP_MASK : 0); }
 	inline bool is_mrcp() { return((flags & MRCP_MASK) != 0); }
+	
+	inline void set_bfcp(bool value) { flags = (flags & ~BFCP_MASK) | (value ? BFCP_MASK : 0); }
+	inline bool is_bfcp() { return((flags & BFCP_MASK) != 0); }
+
 
 	inline void set_ssl(bool value) { flags = (flags & ~SSL_MASK) | (value ? SSL_MASK : 0); }
 	inline bool is_ssl() { return((flags & SSL_MASK) != 0); }

--- a/sniff.cpp
+++ b/sniff.cpp
@@ -1076,6 +1076,7 @@ void save_packet(Call *call, packet_s_process *packetS, int type, u_int8_t force
 			case _t_packet_skinny:
 			case _t_packet_mgcp:
 			case _t_packet_diameter:
+			case _t_packet_bfcp:
 				if(!call->getPcapSip()->isOpen() && enable_save_sip(call)) {
 					string pathfilename = call->get_pathfilename(tsf_sip);
 					if(call->getPcapSip()->open(tsf_sip, pathfilename.c_str(), call->useHandle, call->useDlt)) {
@@ -1164,6 +1165,7 @@ void save_packet(Call *call, packet_s_process *packetS, int type, u_int8_t force
 			case _t_packet_rtp:
 			case _t_packet_dtls:
 			case _t_packet_mrcp:
+			case _t_packet_bfcp:
 				call->save_rtp_pcap = true;
 				break;
 			case _t_packet_rtp_payload:
@@ -2836,7 +2838,10 @@ int get_ip_port_from_sdp(Call *call, packet_s_process *packetS, char *sdp_text, 
 					 { "UDP/TLS/RTP/SAVPF", sdp_proto_srtp }, // RFC 5764
 					 { "msrp/tcp", sdp_proto_msrp }, // Not in IANA, where is this from?
 					 { "UDPSPRT", sdp_proto_sprt }, // Not in IANA, but draft-rajeshkumar-avt-v150-registration-00
-					 { "TCP/MRCPv2", sdp_proto_tcp_mrcpv2 }
+					 { "TCP/MRCPv2", sdp_proto_tcp_mrcpv2 },
+					 { "TCP/BFCP",           sdp_proto_bfcp },
+					 { "UDP/BFCP",           sdp_proto_bfcp },
+          			 { "TCP/TLS/BFCP",       sdp_proto_bfcp }
 				};
 				for(unsigned i = 0; i < sizeof(sdp_protocols) / sizeof(sdp_protocols[0]); i++) {
 					if(!strncasecmp(pointToBeginProtocol, sdp_protocols[i].protocol_str, lengthProtocol) &&
@@ -2846,12 +2851,14 @@ int get_ip_port_from_sdp(Call *call, packet_s_process *packetS, char *sdp_text, 
 				}
 			}
 		}
-		
-		if(sdp_media_type[sdp_media_i] == sdp_media_type_application && 
-		   !(sdp_protocol == sdp_proto_tcp_mrcpv2 && cFilters::saveMrcp())) {
-			continue;
+
+		if(sdp_media_type[sdp_media_i] == sdp_media_type_application &&
+			!((sdp_protocol == sdp_proto_tcp_mrcpv2 && cFilters::saveMrcp()) ||
+			  (sdp_protocol == sdp_proto_bfcp && cFilters::saveBfcp()
+		))) {
+				continue;
 		}
-					       
+
 		s_sdp_media_data *sdp_media_data_item; 
 		if(sdp_media_counter == 0) {
 			sdp_media_data_item = sdp_media_data;

--- a/sniff.h
+++ b/sniff.h
@@ -100,7 +100,8 @@ struct sll2_header {
 #define IS_DTLS(data, datalen) ((datalen) >= 1 && *(u_char*)(data) >= 0x14 && *(u_char*)(data) <= 0x19)
 #define IS_DTLS_HANDSHAKE(data, datalen) ((datalen) >= 1 && *(u_char*)(data) == 0x16)
 #define IS_MRCP(data, datalen) ((datalen) >= 4 && ((char*)(data))[0] == 'M' && ((char*)(data))[1] == 'R' && ((char*)(data))[2] == 'C' && ((char*)(data))[3] == 'P')
-
+#define IS_BFCP(data, datalen) ((data) != NULL && (datalen) >= 12 && ((((const uint8_t *)(data))[0] >> 5) == 0x01 || (((const uint8_t *)(data))[0] >> 5) == 0x02) && \
+								(((const uint8_t *)(data))[1] >= 0x01 && ((const uint8_t *)(data))[1] <= 0x11))
 
 #define if_likely(x) __builtin_expect(!!(x), 1)
 #define if_unlikely(x) __builtin_expect(!!(x), 0)
@@ -115,7 +116,8 @@ enum e_packet_type {
 	_t_packet_mrcp,
 	_t_packet_skinny,
 	_t_packet_mgcp,
-	_t_packet_diameter
+	_t_packet_diameter,
+	_t_packet_bfcp
 };
 
 enum e_packet_s_type {

--- a/sniff_inline.cpp
+++ b/sniff_inline.cpp
@@ -803,6 +803,9 @@ int pcapProcess(sHeaderPacket **header_packet, int pushToStack_queue_index,
 				ppd->datalen = get_udp_data_len(ppd->header_ip, ppd->header_udp, &ppd->data, packet, caplen);
 				ppd->flags.init();
 				ppd->flags.set_ss7(opt_enable_ss7 && (ss7_rudp_portmatrix[ppd->header_udp->get_source()] || ss7_rudp_portmatrix[ppd->header_udp->get_dest()]));
+				if(IS_BFCP(ppd->data, ppd->datalen)) {
+					ppd->flags.set_bfcp(true);
+				}
 			} else if (protocol == IPPROTO_TCP) {
 				ppd->flags.init();
 				ppd->flags.set_tcp(1);
@@ -826,7 +829,10 @@ int pcapProcess(sHeaderPacket **header_packet, int pushToStack_queue_index,
 					ppd->flags.set_ss7(true);
 				} else if(cFilters::saveMrcp() && IS_MRCP(ppd->data, ppd->datalen)) {
 					ppd->flags.set_mrcp(true);
-				} else {
+				}else if(IS_BFCP(ppd->data, ppd->datalen)) {
+					ppd->flags.set_bfcp(true);
+				}
+				else {
 					// not interested in TCP packet other than SIP port
 					if(!opt_ipaccount && !DEBUG_ALL_PACKETS && (ppf & ppf_returnZeroInCheckData)) {
 						//cout << "pcapProcess exit 005" << endl;

--- a/voipmonitor.cpp
+++ b/voipmonitor.cpp
@@ -230,6 +230,7 @@ int opt_saveRTPvideo_only_header = 0;
 int opt_processingRTPvideo = 0;
 int opt_saveMRCP = 0;
 int opt_saveRTCP = 0;		// save RTCP packets to pcap file?
+int opt_saveBFCP = 0;
 bool opt_null_rtppayload = false;
 bool opt_srtp_rtp_decrypt = false;
 bool opt_srtp_rtp_dtls_decrypt = true;
@@ -6851,6 +6852,7 @@ void cConfig::addConfigItems() {
 				->addValues("header:-1|h:-1|cdr_only:-2|c:-2")
 				->setDefaultValueStr("no"));
 			addConfigItem(new FILE_LINE(0) cConfigItem_yesno("savemrcp", &opt_saveMRCP));
+			addConfigItem(new FILE_LINE(0) cConfigItem_yesno("save_bfcp", &opt_saveBFCP));
 			addConfigItem(new FILE_LINE(42210) cConfigItem_yesno("savertcp", &opt_saveRTCP));
 			addConfigItem(new FILE_LINE(0) cConfigItem_integer("ignorertcpjitter", &opt_ignoreRTCPjitter));
 			addConfigItem(new FILE_LINE(42211) cConfigItem_yesno("saveudptl", &opt_saveudptl));
@@ -7999,6 +8001,12 @@ void cConfig::evSetConfigItem(cConfigItem *configItem) {
 				opt_gzip_audiograph = FileZipHandler::gzip;
 			}
 			break;
+		}
+	}
+	if(configItem->config_name == "save_bfcp") {
+		switch(configItem->getValueInt()) {
+		case 1:
+			opt_saveBFCP = 1;
 		}
 	}
 	if(configItem->config_name == "packetbuffer_compress_method") {


### PR DESCRIPTION
In case of sniffing traffic from devices (like Polycom Realpresence Group, Cisco Room Kit and similar ) in meeting rooms during content sharing through BFCP and slides (second non main) video stream, very useful if BFCP traffic will also be saved in pcap for debug purpose.