### PR TITLE
Fix ssl_keylogger link order

### DIFF
--- a/tools/ssl_keylogger/Makefile
+++ b/tools/ssl_keylogger/Makefile
@@ -14,13 +14,13 @@ without_tcp: CPPFLAGS=-g3 $(CPPFLAGS_SSL)
 without_tcp: LDLIBS=-lstdc++ -ldl
 without_tcp: OBJS=sslkeylog.o
 without_tcp: pre_clean sslkeylog.o Makefile
-	$(CC) $(LDLIBS) -shared -o $(DSTLIB) $(OBJS)
+	$(CC) -shared -o $(DSTLIB) $(OBJS) $(LDLIBS)
 
 with_tcp: CPPFLAGS=-g3 -msse4.2 $(shell pkg-config --cflags json-c) -idirafter ../../cloud_router -idirafter ../.. -DTOOLS_LOCAL_H -DCLOUD_ROUTER_H -DCLOUD_ROUTER_SSLKEYLOGGER=1 -DVM_IPV6=1 -DSSLKEYLOG_TCP $(CPPFLAGS_SSL)
 with_tcp: LDLIBS=-lstdc++ -ldl $(shell pkg-config --libs json-c)
 with_tcp: OBJS=sslkeylog.o cloud_router_base.o cloud_router_client.o ip.o tools_global.o
 with_tcp: pre_clean sslkeylog.o cloud_router_base.o cloud_router_client.o ip.o tools_global.o Makefile
-	$(CC) $(LDLIBS) -shared -o $(DSTLIB) $(OBJS)
+	$(CC) -shared -o $(DSTLIB) $(OBJS) $(LDLIBS)
 
 sslkeylog.o: sslkeylog.cpp Makefile
 	$(CC) -c -fPIC $(CPPFLAGS) sslkeylog.cpp -o sslkeylog.o


### PR DESCRIPTION
Move LDLIBS after object files when linking sslkeylog.so. sslkeylog.so uses dlsym(), but the current Makefile passes -ldl before the object files. With linkers using --as-needed this can omit libdl from DT_NEEDED and make LD_PRELOAD users fail at process startup with:
    
symbol lookup error: sslkeylog.so: undefined symbol: dlsym

Putting LDLIBS after OBJS follows the usual linker order and keeps libdl as a dependency when needed.